### PR TITLE
Fix Optimism provider URL retrieval

### DIFF
--- a/methodology.py
+++ b/methodology.py
@@ -134,7 +134,7 @@ class MethodologyBase:
             "binance-smart-chain": decouple.config("BINANCE_INFURA_URL"),
             "polygon-pos": decouple.config("POLYGON_INFURA_URL"),
             "arbitrum-one": decouple.config("ARBITRUM_INFURA_URL"),
-            "optimistic-ethereum": decouple.Config("OPTIMISM_INFURA_URL"),
+            "optimistic-ethereum": decouple.config("OPTIMISM_INFURA_URL"),
             "base": decouple.config("BASE_INFURA_URL"),
         }
 


### PR DESCRIPTION
## Summary
- fix retrieval of Optimism provider URL in `chain_to_provider_url`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e695b524832d9abd22bc0b2c53ef